### PR TITLE
adjust svg size to include margins

### DIFF
--- a/inst/htmlwidgets/pairsD3.js
+++ b/inst/htmlwidgets/pairsD3.js
@@ -9,7 +9,12 @@ HTMLWidgets.widget({
     // save params for reference from resize method
     instance.xin = xin;
     // draw the graphic
-    this.drawGraphic(el, xin, el.offsetWidth, el.offsetHeight);
+    this.drawGraphic(
+      el,
+      xin,
+      el.getBoundingClientRect().width,
+      el.getBoundingClientRect().height
+    );
 
 
   },
@@ -70,8 +75,8 @@ HTMLWidgets.widget({
           .style("opacity", 0);
 
     svg = d3.select(el).append("svg")
-          .attr("width", size * p + padding*2)
-          .attr("height", size * p + padding*2)
+          .attr("width", size * p + padding*2 + xin.leftmar)
+          .attr("height", size * p + padding*2 + xin.topmar)
           .append("g")
           .attr("transform", "translate(" + xin.leftmar + "," + xin.topmar + ")");
 


### PR DESCRIPTION
I believe this pull will solve #5.  The change adds `leftmar` to the `svg` width and `topmar` to the `svg` height.

Before the change, I saw

![image](https://cloud.githubusercontent.com/assets/837910/17364306/07eb0f18-5945-11e6-97bf-b1ab6965d7a7.png)

I now see

![image](https://cloud.githubusercontent.com/assets/837910/17364278/e7852222-5944-11e6-83d0-e832e2ae95a4.png)
